### PR TITLE
Add fixed key layout file for Steam Deck controller

### DIFF
--- a/Vendor_28de_Product_11ff.kl
+++ b/Vendor_28de_Product_11ff.kl
@@ -1,0 +1,74 @@
+# Copyright (C) 2020 The Android Open Source Project
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+#
+# Steam Controller - Model 1001 - USB
+#
+
+# Mapping according to https://developer.android.com/training/game-controllers/controller-input.html
+
+key 304   BUTTON_A
+key 305   BUTTON_B
+key 307   BUTTON_X
+key 308   BUTTON_Y
+
+key 310   BUTTON_L1
+key 311   BUTTON_R1
+key 312   BUTTON_L2
+key 313   BUTTON_R2
+
+# Triggers.
+axis 0x02 LTRIGGER
+axis 0x05 RTRIGGER
+
+# Left and right stick.
+axis 0x00 X
+axis 0x01 Y
+
+# Right stick / mousepad
+axis 0x03 Z
+axis 0x04 RZ
+
+key 317   BUTTON_THUMBL
+key 318   BUTTON_THUMBR
+
+# Hat.
+axis 0x10 HAT_X
+axis 0x11 HAT_Y
+
+# Dpad (clicks)
+key 544 DPAD_UP
+key 545 DPAD_DOWN
+key 546 DPAD_LEFT
+key 547 DPAD_RIGHT
+
+# Touching the dpad (light touch without pressing down)
+key 289 BUTTON_1
+# Touching the "right stick" / mousepad (light touch without pressing down)
+key 290 BUTTON_2
+
+# Pressing the large paddle on the back, left (linux BTN_WHEEL / BTN_GEAR_DOWN)
+key 336 BUTTON_3
+# Pressing the large paddle on the back, right (linux BTN_GEAR_UP)
+key 337 BUTTON_4
+
+
+# Mapping according to https://www.kernel.org/doc/Documentation/input/gamepad.txt
+# Left arrow
+key 314   BUTTON_SELECT
+# Right arrow
+key 315   BUTTON_START
+
+# Steam key
+key 316   BUTTON_MODE

--- a/Vendor_28de_Product_11ff.kl
+++ b/Vendor_28de_Product_11ff.kl
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 #
-# Steam Controller - Model 1001 - USB
+# Steam Deck Controller - USB
 #
 
 # Mapping according to https://developer.android.com/training/game-controllers/controller-input.html
@@ -25,8 +25,6 @@ key 308   BUTTON_Y
 
 key 310   BUTTON_L1
 key 311   BUTTON_R1
-key 312   BUTTON_L2
-key 313   BUTTON_R2
 
 # Triggers.
 axis 0x02 LTRIGGER
@@ -46,23 +44,6 @@ key 318   BUTTON_THUMBR
 # Hat.
 axis 0x10 HAT_X
 axis 0x11 HAT_Y
-
-# Dpad (clicks)
-key 544 DPAD_UP
-key 545 DPAD_DOWN
-key 546 DPAD_LEFT
-key 547 DPAD_RIGHT
-
-# Touching the dpad (light touch without pressing down)
-key 289 BUTTON_1
-# Touching the "right stick" / mousepad (light touch without pressing down)
-key 290 BUTTON_2
-
-# Pressing the large paddle on the back, left (linux BTN_WHEEL / BTN_GEAR_DOWN)
-key 336 BUTTON_3
-# Pressing the large paddle on the back, right (linux BTN_GEAR_UP)
-key 337 BUTTON_4
-
 
 # Mapping according to https://www.kernel.org/doc/Documentation/input/gamepad.txt
 # Left arrow

--- a/steamos-waydroid-installer.sh
+++ b/steamos-waydroid-installer.sh
@@ -242,6 +242,10 @@ cp android.jpg ~/Android_Waydroid/android.jpg
 echo -e "$current_password\n" | sudo -S cp cage/cage cage/wlr-randr /usr/bin
 echo -e "$current_password\n" | sudo -S chmod +x /usr/bin/cage /usr/bin/wlr-randr
 
+# copy fixed key layout for Steam Controller
+echo -e "$current_password\n" | sudo -S mkdir -p /var/lib/waydroid/overlay/system/usr/keylayout
+echo -e "$current_password\n" | sudo -S cp Vendor_28de_Product_11ff.kl /var/lib/waydroid/overlay/system/usr/keylayout/
+
 # lets check if this is a reinstall
 grep redfin /var/lib/waydroid/waydroid_base.prop &> /dev/null
 if [ $? -eq 0 ]


### PR DESCRIPTION
The current key layout file used for the Steam Deck's virtual controller incorrectly binds the triggers to the right stick (with the right stick itself seemingly bound to nothing). This can be verified by using [Gamepad Tester](https://play.google.com/store/apps/details?id=com.chimera.saturday.evogamepadtester) by selva sundar. I've also noticed this layout binding issue in games such as *Minecraft*, *Riptide GP2* and *Asphalt 9: Legends*.

I have been able to fix this by adding a custom `Vendor_28de_Product_11ff.kl` key layout file to `/var/lib/waydroid/overlay/system/usr/keylayout/`, which my PR adds as an additional step in the shell script. I'm not sure if there are any other Product IDs that could be associated with the virtual controller, so some additional testing on other Steam Decks may be required.

The file itself is based on the [Steam Controller key layout](https://android.googlesource.com/platform/frameworks/base/+/master/data/keyboards/Vendor_28de_Product_1102.kl) from the AOSP, with the following change to make the triggers work:

```diff
# Triggers.
-axis 0x15 LTRIGGER
-axis 0x14 RTRIGGER
+axis 0x02 LTRIGGER
+axis 0x05 RTRIGGER
```

I've also removed some unused inputs such as the rear buttons, since Steam's virtual controller does not directly expose them.

This issue did not affect the [Game Controller Tester](https://play.google.com/store/apps/details?id=uk.co.powgames.gamecondiag&hl=en&gl=US) app by POW Games UK, which presumably uses a different method of reading controller inputs and will still work fine as a result.