### PR TITLE
Added app shortcuts

### DIFF
--- a/steamos-waydroid-installer.sh
+++ b/steamos-waydroid-installer.sh
@@ -157,12 +157,21 @@ echo -e "$current_password\n" | sudo -S chown root:root /etc/sudoers.d/zzzzzzzz-
 cat > ~/Android_Waydroid/Android_Waydroid_Cage.sh << EOF
 #!/bin/bash
 
+shortcut=$1
+
 killall -9 cage &> /dev/null
 sudo /usr/bin/waydroid-container-stop
 sudo /usr/bin/waydroid-container-start
 
-# Launch Waydroid via cage
-cage -- ~/Android_Waydroid/cage_helper.sh
+# If app name provided launch cage with the script for it
+if [ -z "$1" ]
+	then
+		# Launch Waydroid app via cage
+		cage -- ~/Android_Waydroid/$shortcut.sh
+	else
+		# Launch Waydroid full ui via cage
+		cage -- ~/Android_Waydroid/cage_helper.sh
+fi
 EOF
 
 # waydroid launcher - cage helper script
@@ -175,6 +184,21 @@ wlr-randr --output X11-1 --custom-mode 1280x800@60Hz
 
 sleep 15
 sudo /usr/bin/waydroid-fix-controllers
+EOF
+
+# template file for launching apps directly
+cat > ~/Android_Waydroid/template.sh << EOF
+#!/bin/bash
+
+# Launch Waydroid via cage, don't show UI
+wlr-randr --output X11-1 --custom-mode 1280x800@60Hz
+/usr/bin/waydroid session start \$@ &
+
+sleep 15
+sudo /usr/bin/waydroid-fix-controllers
+
+# launch the android app automatically
+/usr/bin/waydroid app launch com.netflix.mediaclient  &
 EOF
 
 # uninstall script

--- a/steamos-waydroid-installer.sh
+++ b/steamos-waydroid-installer.sh
@@ -157,17 +157,17 @@ echo -e "$current_password\n" | sudo -S chown root:root /etc/sudoers.d/zzzzzzzz-
 cat > ~/Android_Waydroid/Android_Waydroid_Cage.sh << EOF
 #!/bin/bash
 
-shortcut=$1
+shortcut=\$1
 
 killall -9 cage &> /dev/null
 sudo /usr/bin/waydroid-container-stop
 sudo /usr/bin/waydroid-container-start
 
 # If app name provided launch cage with the script for it
-if [ -z "$1" ]
+if [ -z "\$1" ]
 	then
 		# Launch Waydroid app via cage
-		cage -- ~/Android_Waydroid/$shortcut.sh
+		cage -- ~/Android_Waydroid/\$shortcut.sh
 	else
 		# Launch Waydroid full ui via cage
 		cage -- ~/Android_Waydroid/cage_helper.sh


### PR DESCRIPTION
Added template file to installer and functionality to launch cage with a different script if argument provided in Steam target.

To add a Waydroid app to Steam follow these steps:

1. Open the Start Menu, then under Waydroid find the app you want to add to Steam. Right click on it and select Edit Application.
2. On the Application tab copy the contents of the Arguments box
3. Go to "/home/deck/Android_Waydroid/" and open "template.sh". Replace "app launch com.netflix.mediaclient" with the value copied in the last step.
4. Save the file as the name of the app, for example netflix. Make sure to keep the.sh file extension.
5. In the same folder, right click on "Android_Waydroid_Cage.sh" and select Add to Steam.
6. In Steam go to the added games Properties and in the Target box at the end add the name of the app. For example adding netflix the Target box would contain "/home/deck/Android_Waydroid/Android_Waydroid_Cage.sh" netflix.
7. Starting the game should open directly into the app.