### PR TITLE
Further improve Roblox experience

### DIFF
--- a/steamos-waydroid-installer.sh
+++ b/steamos-waydroid-installer.sh
@@ -236,7 +236,7 @@ if [ -z "\$1" ]
 			sudo /usr/bin/waydroid-fix-controllers'
 
 	else
-		# launch option provided. launch Waydroid via cage but do not show full ui, launch the from the arguments
+		# launch option provided. launch Waydroid via cage but do not show full ui, launch the package from the arguments
 		cage -- env PACKAGE="\$1" bash -c 'wlr-randr --output X11-1 --custom-mode 1280x800@60Hz ; \\
 			/usr/bin/waydroid session start \$@ & \\
 


### PR DESCRIPTION
- by default, use libndk_fixer.so for running com.roblox.client package from shortcut (Android_Waydroid_Cage.sh)
- allow user to explicitly set this behavior - by default it is AUTO (Waydroid-Toolbox.sh)
- add a new script for setting waydroid properties, can be further extended in the future (waydroid-set-properties)
- improve cage kill command by allowing it to shutdown gracefully (Android_Waydroid_Cage.sh)
- couple of tiny changes to package launch commands - makes things more reliable for me (Android_Waydroid_Cage.sh)