### PR TITLE
perf: use `--depth=1` shallow clones

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,7 +124,7 @@ Read the sections below carefully!
 1. Go into Desktop Mode and open a konsole terminal.
 2. Clone the github repo. \
    cd ~/ \
-   git clone https://github.com/ryanrudolfoba/steamos-waydroid-installer
+   git clone --depth=1 https://github.com/ryanrudolfoba/steamos-waydroid-installer
 3. Execute the script! \
    cd ~/steamos-waydroid-installer \
    chmod +x steamos-waydroid-installer.sh \

--- a/extras/Waydroid-Updater.sh
+++ b/extras/Waydroid-Updater.sh
@@ -2,7 +2,7 @@ echo This will clone the later version of the SteamOS Waydroid Installer script 
 sleep 5
 cd ~/
 rm -rf ~/steamos-waydroid-installer
-git clone https://github.com/ryanrudolfoba/steamos-waydroid-installer
+git clone --depth=1 https://github.com/ryanrudolfoba/steamos-waydroid-installer
 cd ~/steamos-waydroid-installer
 chmod +x steamos-waydroid-installer.sh
 ./steamos-waydroid-installer.sh

--- a/steamos-waydroid-installer.sh
+++ b/steamos-waydroid-installer.sh
@@ -120,14 +120,14 @@ echo Cloning casualsnek repo.
 echo This can take a few minutes depending on the speed of the internet connection and if github is having issues.
 echo If the git clone is slow - cancel the script \(CTL-C\) and run it again.
 
-echo -e "$current_password\n" | sudo -S rm -rf ~/AUR/waydroid*  &> /dev/null && git clone $AUR_CASUALSNEK $DIR_CASUALSNEK &> /dev/null
+echo -e "$current_password\n" | sudo -S rm -rf ~/AUR/waydroid*  &> /dev/null && git clone --depth=1 $AUR_CASUALSNEK $DIR_CASUALSNEK &> /dev/null
 
 if [ $? -eq 0 ]
 then
 	echo Casualsnek repo has been successfully cloned!
 else
 	echo Error cloning Casualsnek repo! Trying to clone again using backup repo.
-	echo -e "$current_password\n" | sudo -S rm -rf ~/AUR/waydroid*  &> /dev/null && git clone $AUR_CASUALSNEK2 $DIR_CASUALSNEK &> /dev/null
+	echo -e "$current_password\n" | sudo -S rm -rf ~/AUR/waydroid*  &> /dev/null && git clone --depth=1 $AUR_CASUALSNEK2 $DIR_CASUALSNEK &> /dev/null
 
 	if [ $? -eq 0 ]
 	then


### PR DESCRIPTION
## Summary

Use a more efficient shallow clone 

## Details

- rather than cloning the entire history of repos, do shallow clones with a [depth](https://git-scm.com/docs/git-clone#Documentation/git-clone.txt-code--depthcodeemltdepthgtem) of 1
  - this should make it more efficient, particularly when there are many commits or many large commits
    - since the repos do have binary blobs in them, the latter is more relevant in this case
  - since the history is unused by regular end users, there is no need to fetch/download it

## Notes to Reviewers

- could alternatively do a [bare](https://git-scm.com/docs/git-clone#Documentation/git-clone.txt-code--barecode) clone to be even more efficient (no `.git` dir what-so-ever)
  - but I thought a shallow clone is a bit less intrusive for now
    - and is reversible, if needed (i.e. a local shallow clone can fetch the rest of the depth)