### PR TITLE
docs: use markdown link for the controller config

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,7 +139,7 @@ Read the sections below carefully!
 ## Steam Deck Controller Layout
 [Thanks to DanielLester83!](https://github.com/ryanrudolfoba/SteamOS-Waydroid-Installer/issues/134)
 
-Search 'Waydroid' in the community templates or maybe this link would work steam://controllerconfig/3665077347/3304296813
+Search 'Waydroid' in the community templates or try this link: [steam://controllerconfig/3665077347/3304296813](steam://controllerconfig/3665077347/3304296813)
 
 This maps the back buttons to function keys for use with android key remappers like this https://github.com/keymapperorg/KeyMapper
 

--- a/README.md
+++ b/README.md
@@ -139,7 +139,7 @@ Read the sections below carefully!
 ## Steam Deck Controller Layout
 [Thanks to DanielLester83!](https://github.com/ryanrudolfoba/SteamOS-Waydroid-Installer/issues/134)
 
-Search 'Waydroid' in the community templates or try this link: [steam://controllerconfig/3665077347/3304296813](steam://controllerconfig/3665077347/3304296813)
+Search 'Waydroid' in the community templates or try this link: <a href="steam://controllerconfig/3665077347/3304296813">steam://controllerconfig/3665077347/3304296813</a>
 
 This maps the back buttons to function keys for use with android key remappers like this https://github.com/keymapperorg/KeyMapper
 


### PR DESCRIPTION
## Summary

Properly link the controller config

## Details

- GH markdown does not seem to automatically recognize this as a link given the `steam://` prefix for deep linking
  - so manually link it instead then
  
## Verification

See the [rendered markdown in this branch](https://github.com/ryanrudolfoba/SteamOS-Waydroid-Installer/blob/dd1d69200781a4bbd0d9236393b574308a010b42/README.md#steam-deck-controller-layout)