### PR TITLE
github: add YT links in issue chooser

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,7 @@
+contact_links:
+  - name: SteamOS Waydroid Install Guide
+    url: https://www.youtube.com/watch?v=06T-h-jPVx8
+    about: YouTube video on installing
+  - name: SteamOS Waydroid Upgrade Guide
+    url: https://www.youtube.com/watch?v=CJAMwIb_oI0
+    about: YouTube video on upgrading


### PR DESCRIPTION
## Summary

As you often link people to your YT vids for support, these will now be directly linked before a user files an issue

Following GitHub Docs on [configuring the template chooser](https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/configuring-issue-templates-for-your-repository#configuring-the-template-chooser)

## Details

  - added latest install vid and latest update vid

## Future Work

    - [ ] might want to link to a playlist where the latest vids are first? no need to update any links then