### PR TITLE
feat: add option to install Android 11 TV image

### DIFF
--- a/steamos-waydroid-installer.sh
+++ b/steamos-waydroid-installer.sh
@@ -13,6 +13,8 @@ kernel_version=$(uname -r | cut -d "-" -f 1-5 )
 stable_kernel1=6.1.52-valve16-1-neptune-61
 stable_kernel2=6.5.0-valve22-1-neptune-65
 beta_kernel1=6.5.0-valve23-1-neptune-65
+ANDROID_TV_IMG=https://github.com/ryanrudolfoba/SteamOS-Waydroid-Installer/releases/download/Android11TV/lineage-18.1-20241220-UNOFFICIAL-10MinuteSteamDeckGamer-WaydroidATV.zip
+ANDROID_TV_IMG_MD5=4b0236af2d83164135d86872e27ce6af
 AUR_CASUALSNEK=https://github.com/casualsnek/waydroid_script.git
 AUR_CASUALSNEK2=https://github.com/ryanrudolfoba/waydroid_script.git
 DIR_CASUALSNEK=~/AUR/waydroid/waydroid_script
@@ -290,8 +292,20 @@ else
 
 		elif [ "$Choice" == "TV" ]
 		then
-			echo Android TV chosen!
-			exit
+			echo Downloading Android TV image
+			echo -e "$current_password\n" | sudo -S curl -o ~/waydroid/images/androidtv.zip $ANDROID_TV_IMG -L
+			hash=$(md5sum "/home/deck/waydroid/images/androidtv.zip" | awk '{print $1}')
+			# Verify the MD5 hash
+			if [[ "$hash" != "$ANDROID_TV_IMG_MD5" ]]; then
+				echo MD5 hash mismatch for Android TV image, indicating a corrupted download. This might be due to a network error, you can try again.
+				cleanup_exit
+			fi
+
+			echo Extracting Archive
+			echo -e "$current_password\n" | sudo -S unzip -o ~/waydroid/images/androidtv -d ~/waydroid/images
+			echo -e "$current_password\n" | sudo -S rm ~/waydroid/images/androidtv.zip
+			echo Initializing Waydroid
+			echo -e "$current_password\n" | sudo -S waydroid init
 		fi
 
 	# check if waydroid initialization completed without errors


### PR DESCRIPTION
## Summary

Makes the "TV" choice work by downloading [the released Android 11 TV image](https://github.com/ryanrudolfoba/SteamOS-Waydroid-Installer/releases/tag/Android11TV)
This is a squashed version of #220 / #225 with a few small additional fixes + changes

## Details

- makes the "TV" choice work now instead of immediately exiting
- uses the built Android TV image hosted on this repo's GH Releases
  - verifies its md5 hash as well, as requested in https://github.com/ryanrudolfoba/SteamOS-Waydroid-Installer/pull/220#issuecomment-2582690416
  
## Credits

Original code is from @theredenemy (who is also listed as co-author on [the commit](https://github.com/ryanrudolfoba/SteamOS-Waydroid-Installer/pull/228/commits/4c22930a2e24bff289ec0d1b63ecf9e5d5f74061)) from #220 with significant modifications by myself

