### PR TITLE
clean: remove duplicate unused `STEAMOS_VERSION` variable

### DIFF
--- a/steamos-waydroid-installer.sh
+++ b/steamos-waydroid-installer.sh
@@ -16,7 +16,6 @@ beta_kernel1=6.5.0-valve23-1-neptune-65
 AUR_CASUALSNEK=https://github.com/casualsnek/waydroid_script.git
 AUR_CASUALSNEK2=https://github.com/ryanrudolfoba/waydroid_script.git
 DIR_CASUALSNEK=~/AUR/waydroid/waydroid_script
-STEAMOS_VERSION=$(grep VERSION_ID /etc/os-release | cut -d "=" -f 2)
 FREE_HOME=$(df /home --output=avail | tail -n1)
 FREE_VAR=$(df /var --output=avail | tail -n1)
 


### PR DESCRIPTION
## Summary

Remove an unused variable

## Details

- the lowercase `steamos_version` variable above this one is used instead; the all caps one is currently entirely unused, so remove it
  - `shellcheck` notices this with code `SC2034`