### PR TITLE
style: consistent indentation in `Android_Waydroid_Cage.sh`

### DIFF
--- a/extras/Android_Waydroid_Cage-experimental.sh
+++ b/extras/Android_Waydroid_Cage-experimental.sh
@@ -65,39 +65,39 @@ fi
 
 # Check if non Steam shortcut has the game / app as the launch option
 if [ -z "$1" ]
-	then
-		# launch option not provided. launch Waydroid via cage and show the full ui right away
-		cage -- bash -c 'wlr-randr --output X11-1 --transform $TRANSFORM --custom-mode ${RESOLUTION}@60Hz ;	\
-			/usr/bin/waydroid session start $@ & \
-			sleep 5 ;\
-			waydroid prop set persist.waydroid.height $HEIGHT ;\
-			waydroid prop set persist.waydroid.width $WIDTH ;\
-			/usr/bin/waydroid session stop ;\
-			
-			/usr/bin/waydroid session start $@ & \
-			sleep 15 ; \
+then
+	# launch option not provided. launch Waydroid via cage and show the full ui right away
+	cage -- bash -c 'wlr-randr --output X11-1 --transform $TRANSFORM --custom-mode ${RESOLUTION}@60Hz ;	\
+		/usr/bin/waydroid session start $@ & \
+		sleep 5 ;\
+		waydroid prop set persist.waydroid.height $HEIGHT ;\
+		waydroid prop set persist.waydroid.width $WIDTH ;\
+		/usr/bin/waydroid session stop ;\
 
-			sudo /usr/bin/waydroid-startup-scripts ;\
-			/usr/bin/waydroid show-full-ui $@ & '
-	else
-		# launch option provided. launch Waydroid via cage but do not show full ui, launch the app from the arguments, then launch the full ui so it doesnt crash when exiting the app provided
-		cage -- env PACKAGE="$1" bash -c 'wlr-randr --output X11-1 --transform $TRANSFORM --custom-mode ${RESOLUTION}@60Hz ; \
-			/usr/bin/waydroid session start $@ & \
-			sleep 5 ;\
-			waydroid prop set persist.waydroid.height $HEIGHT ;\
-			waydroid prop set persist.waydroid.width $WIDTH ;\
-			/usr/bin/waydroid session stop ;\
-			
-			/usr/bin/waydroid session start $@ & \
-			sleep 15 ; \
+		/usr/bin/waydroid session start $@ & \
+		sleep 15 ; \
 
-			sudo /usr/bin/waydroid-startup-scripts ; \
+		sudo /usr/bin/waydroid-startup-scripts ;\
+		/usr/bin/waydroid show-full-ui $@ & '
+else
+	# launch option provided. launch Waydroid via cage but do not show full ui, launch the app from the arguments, then launch the full ui so it doesnt crash when exiting the app provided
+	cage -- env PACKAGE="$1" bash -c 'wlr-randr --output X11-1 --transform $TRANSFORM --custom-mode ${RESOLUTION}@60Hz ; \
+		/usr/bin/waydroid session start $@ & \
+		sleep 5 ;\
+		waydroid prop set persist.waydroid.height $HEIGHT ;\
+		waydroid prop set persist.waydroid.width $WIDTH ;\
+		/usr/bin/waydroid session stop ;\
 
-			sleep 5 ; \
-			/usr/bin/waydroid app launch $PACKAGE & \
+		/usr/bin/waydroid session start $@ & \
+		sleep 15 ; \
 
-   			sleep 1 ; \
-      			/usr/bin/waydroid show-full-ui &'
+		sudo /usr/bin/waydroid-startup-scripts ; \
+
+		sleep 5 ; \
+		/usr/bin/waydroid app launch $PACKAGE & \
+
+		sleep 1 ; \
+		/usr/bin/waydroid show-full-ui &'
 fi
 
 # Reset cage so it doesn't nuke the display environment variable on exit

--- a/extras/Android_Waydroid_Cage.sh
+++ b/extras/Android_Waydroid_Cage.sh
@@ -40,24 +40,24 @@ fi
 
 # Check if non Steam shortcut has the game / app as the launch option
 if [ -z "$1" ]
-	then
-		# launch option not provided. launch Waydroid via cage and show the full ui right away
-		cage -- bash -c 'wlr-randr --output X11-1 --custom-mode $RESOLUTION@60Hz ; \
-			/usr/bin/waydroid show-full-ui $@ & \
+then
+	# launch option not provided. launch Waydroid via cage and show the full ui right away
+	cage -- bash -c 'wlr-randr --output X11-1 --custom-mode $RESOLUTION@60Hz ; \
+		/usr/bin/waydroid show-full-ui $@ & \
 
-			sudo /usr/bin/waydroid-startup-scripts'
-	else
-		# launch option provided. launch Waydroid via cage but do not show full ui, launch the app from the arguments, then launch the full ui so it doesnt crash when exiting the app provided
-		cage -- env PACKAGE="$1" bash -c 'wlr-randr --output X11-1 --custom-mode $RESOLUTION@60Hz ; \
-			/usr/bin/waydroid session start $@ & \
+		sudo /usr/bin/waydroid-startup-scripts'
+else
+	# launch option provided. launch Waydroid via cage but do not show full ui, launch the app from the arguments, then launch the full ui so it doesnt crash when exiting the app provided
+	cage -- env PACKAGE="$1" bash -c 'wlr-randr --output X11-1 --custom-mode $RESOLUTION@60Hz ; \
+		/usr/bin/waydroid session start $@ & \
 
-			sudo /usr/bin/waydroid-startup-scripts ; \
+		sudo /usr/bin/waydroid-startup-scripts ; \
 
-			sleep 1 ; \
-			/usr/bin/waydroid app launch $PACKAGE & \
+		sleep 1 ; \
+		/usr/bin/waydroid app launch $PACKAGE & \
 
-			sleep 1 ; \
-			/usr/bin/waydroid show-full-ui $@ &'
+		sleep 1 ; \
+		/usr/bin/waydroid show-full-ui $@ &'
 fi
 
 # Reset cage so it doesn't nuke the display environment variable on exit


### PR DESCRIPTION
## Summary

Ensure consistent indentation in scripts

## Details

- one of the conditional blocks was inconsistently indented twice
  - the `then` and `else` were indented, unlike the rest of the scripts in this repo

- also fix mixed indentation issues in `Android_Waydroid_Cage-experimental.sh`
  - this was done for `Android_Waydroid_Cage.sh` in #201 but not for the `-experimental` variant
  
## Verification

Purely a whitespace change, no semantic or syntactic changes

## Future Work

1. [x] Get `shfmt` working to automate this a la #224