### PR TITLE
feat: print the SHA of the script for debugging

### DIFF
--- a/steamos-waydroid-installer.sh
+++ b/steamos-waydroid-installer.sh
@@ -8,6 +8,7 @@ echo YT - 10MinuteSteamDeckGamer
 sleep 2
 
 # define variables here
+script_version_sha=$(git rev-parse HEAD)
 steamos_version=$(cat /etc/os-release | grep -i version_id | cut -d "=" -f2)
 kernel_version=$(uname -r | cut -d "-" -f 1-5 )
 stable_kernel1=6.1.52-valve16-1-neptune-61
@@ -136,6 +137,8 @@ check_waydroid_init () {
 		cleanup_exit
 	fi
 }
+
+echo script version: $script_version_sha
 
 # sanity check - are you running this in Desktop Mode or ssh / virtual tty session?
 xdpyinfo &> /dev/null

--- a/steamos-waydroid-installer.sh
+++ b/steamos-waydroid-installer.sh
@@ -8,7 +8,7 @@ echo YT - 10MinuteSteamDeckGamer
 sleep 2
 
 # define variables here
-script_version_sha=$(git rev-parse HEAD)
+script_version_sha=$(git rev-parse --short HEAD)
 steamos_version=$(cat /etc/os-release | grep -i version_id | cut -d "=" -f2)
 kernel_version=$(uname -r | cut -d "-" -f 1-5 )
 stable_kernel1=6.1.52-valve16-1-neptune-61


### PR DESCRIPTION
## Summary

Print out the version of the script for debug log purposes

## Details

- this way we know what version of the script users are on
  - and from there know what features and bugs are present
  - particularly as the [issue template's self-assessment of "latest"](https://github.com/ryanrudolfoba/SteamOS-Waydroid-Installer/blob/ceb947867ba2fbdf582db81930155df88036a34e/.github/ISSUE_TEMPLATE/01-error-report.yml?plain=1#L10) has unfortunately been insufficient based on recent issues
    - (as I predicted in #217's "note", but worse than I imagined 😕)
  
## Future Work

1. [ ] If desired, we could also check this version against the latest version of the repo and either auto-update or print that the version is outdated and to manually update