### PR TITLE
feat: add Desktop shortcut for `Waydroid-Updater.sh`

### DIFF
--- a/steamos-waydroid-installer.sh
+++ b/steamos-waydroid-installer.sh
@@ -330,13 +330,12 @@ echo -e "$current_password\n" | sudo -S chmod +x /usr/bin/waydroid-startup-scrip
 echo -e "$current_password\n" | sudo -S cp extras/zzzzzzzz-waydroid /etc/sudoers.d/zzzzzzzz-waydroid
 echo -e "$current_password\n" | sudo -S chown root:root /etc/sudoers.d/zzzzzzzz-waydroid
 
-# waydroid launcher - cage
-cp extras/Android_Waydroid_Cage.sh ~/Android_Waydroid/Android_Waydroid_Cage.sh
-
 # custom configs done. lets move them to the correct location
-cp $PWD/extras/Waydroid-Toolbox.sh $PWD/extras/Android_Waydroid_Cage-experimental.sh ~/Android_Waydroid
+cp extras/Android_Waydroid_Cage.sh extras/Waydroid-Toolbox.sh extras/Waydroid-Updater.sh extras/Android_Waydroid_Cage-experimental.sh ~/Android_Waydroid
 chmod +x ~/Android_Waydroid/*.sh
+# desktop shortcuts for toolbox + updater
 ln -s ~/Android_Waydroid/Waydroid-Toolbox.sh ~/Desktop/Waydroid-Toolbox &> /dev/null
+ln -s ~/Android_Waydroid/Waydroid-Updater.sh ~/Desktop/Waydroid-Updater &> /dev/null
 
 # lets copy cage and wlr-randr to the correct folder
 echo -e "$current_password\n" | sudo -S cp cage/cage cage/wlr-randr /usr/bin


### PR DESCRIPTION
## Summary

Symlink a desktop shortcut for [`Waydroid-Updater.sh`](https://github.com/ryanrudolfoba/SteamOS-Waydroid-Installer/blob/ceb947867ba2fbdf582db81930155df88036a34e/extras/Waydroid-Updater.sh)

## Details

- as discussed in https://github.com/ryanrudolfoba/SteamOS-Waydroid-Installer/issues/256#issuecomment-2686693743 et al, to make it easier for users to update the script by just running it from the desktop

- also simplifies some duplicative / inconsistent code that moved files around
  - the `cage` script can be in the same `cp` block that moves the other `extras/` scripts
  - `$PWD` was only used here and nowhere else, so remove it as inconsistent
  
## Future Work

1. [ ] might make sense to add the toolbox + updater to Steam as well?
   - given how infrequently those are normally used though, that may be more confusing than helpful
