### PR TITLE
fix: also perform devmode fallback if `steamos-devmode` command fails

### DIFF
--- a/steamos-waydroid-installer.sh
+++ b/steamos-waydroid-installer.sh
@@ -268,8 +268,8 @@ else
 fi
 
 # check if steamos-devmode command exists
-which steamos-devmode &> /dev/null
-if [ $? -eq 0 ]
+devmode_exists=$(which steamos-devmode &> /dev/null; echo $?)
+if [ "$devmode_exists" -eq 0 ]
 then
 	# disable the SteamOS readonly and initialize the keyring using the steamos-devmode command
 	echo steamos-devmode command exists. Using steamos-devmode to unlock the readonly and initialize the keyring
@@ -282,14 +282,18 @@ fi
 if [ $? -eq 0 ]
 then
 	echo pacman keyring has been initialized!
-else
-	echo Error initializing keyring! Trying fallback.
+elif [ "$devmode_exists" -eq 0 ]
+then
+	echo Error initializing keyring!
 	devmode_fallback
 	if [ $? -eq 0 ]
 	then
 		echo Error initializing keyring with fallback!
 		cleanup_exit
 	fi
+else
+	echo Error initializing keyring with fallback!
+	cleanup_exit
 fi
 
 # lets install and enable the binder module so we can start waydroid right away


### PR DESCRIPTION
## Summary

Per https://github.com/ryanrudolfoba/SteamOS-Waydroid-Installer/issues/265#issuecomment-2773010470, there is the case where the `steamos-devmode` command _exists_ but returns a non-zero exit code. In that case, we can also try the fallback.

## Details

- the command can both exist _and_ fail, so the fallback should be attempted in the failure case as well

- refactor the fallback into the aptly named `devmode_fallback` function to run it multiple times
- remove the duplicative "run the script again" log as `cleanup_exit` already prints that (and it probably won't work the second time in this case)
  - also fix grammatical typo "command does not exists" -> "[...] exist"

## Notes to Reviewers

~In the case the `steamos-devmode` command doesn't exist _and_ the fallback fails, this will end up running the fallback twice~
- ~that should be nbd, but could be refactored -- as "Future Work" -- the initialization check exit code could be 'cached' as a variable to cross-check it in this case~
- I've refactored that in an additional commit on this PR: https://github.com/ryanrudolfoba/SteamOS-Waydroid-Installer/pull/268/commits/b6cd834961f382a7c1160be37719d93c9de456dd