### PR TITLE
fix: silence the first `grep` as well

### DIFF
--- a/steamos-waydroid-installer.sh
+++ b/steamos-waydroid-installer.sh
@@ -183,7 +183,7 @@ fi
 
 # sanity check - is this a reinstall?
 # this sanity check will go away once the var trick is completed
-grep redfin /var/lib/waydroid/waydroid_base.prop || grep PH7M_EU_5596 /var/lib/waydroid/waydroid_base.prop &> /dev/null
+grep redfin /var/lib/waydroid/waydroid_base.prop &> /dev/null || grep PH7M_EU_5596 /var/lib/waydroid/waydroid_base.prop &> /dev/null
 if [ $? -eq 0 ]
 then
 	echo This seems to be a reinstall. var sanity check not needed.
@@ -369,7 +369,7 @@ echo -e "$current_password\n" | sudo -S cp cage/cage cage/wlr-randr /usr/bin
 echo -e "$current_password\n" | sudo -S chmod +x /usr/bin/cage /usr/bin/wlr-randr
 
 # lets check if this is a reinstall
-grep redfin /var/lib/waydroid/waydroid_base.prop || grep PH7M_EU_5596 /var/lib/waydroid/waydroid_base.prop &> /dev/null
+grep redfin /var/lib/waydroid/waydroid_base.prop &> /dev/null || grep PH7M_EU_5596 /var/lib/waydroid/waydroid_base.prop &> /dev/null
 if [ $? -eq 0 ]
 then
 	echo This seems to be a reinstall. No further config needed.


### PR DESCRIPTION
## Motivation

From #265 I noticed the error message `grep: /var/lib/waydroid/waydroid_base.prop no such file` was happening despite the script continuing and the fix from #261 / https://github.com/ryanrudolfoba/SteamOS-Waydroid-Installer/commit/2a6fbfa6b25ba28c4088e14077444e7d214bc01e

## Details

- silence the first `grep` too so it doesn't print an error message that may confuse users
  - an error message is _expected_ on first install and is why there is a return code check after
  
## Notes to Reviewers

- I have not tested this yet
- Should be added to [the `testing` branch's checks as well](https://github.com/ryanrudolfoba/SteamOS-Waydroid-Installer/commit/3c5d74b208d5eb3668a7ad56a03b21f9ba0ae15a), since they haven't been merged to `main` yet
  - note that this check is done twice, and so itself could be refactored into a function as well