### PR TITLE
Testing - Edit README to clone testing branch

### DIFF
--- a/README.md
+++ b/README.md
@@ -187,7 +187,7 @@ SteamOS has been stuck on 6.1.52-valve16-1 for several releases now so I think t
 
    ```sh
    cd ~/
-   git clone --depth=1 https://github.com/ryanrudolfoba/steamos-waydroid-installer
+   git clone --depth=1 -b testing https://github.com/ryanrudolfoba/steamos-waydroid-installer
    ```
 
 3. Execute the script! \


### PR DESCRIPTION
a really small change to the install steps so the code actually clones the testing branch, since it currently clones the regular script and shows kernel not supported. Remove it when you decide to merge the 3.7.x fix into the main branch.