### PR TITLE
Use Github hosted AUR due to outages

### DIFF
--- a/steamos-waydroid-installer.sh
+++ b/steamos-waydroid-installer.sh
@@ -11,7 +11,6 @@ sleep 2
 script_version_sha=$(git rev-parse --short HEAD)
 steamos_version=$(cat /etc/os-release | grep -i version_id | cut -d "=" -f2)
 WORKING_DIR=$(pwd)
-BINDER_AUR=https://aur.archlinux.org/binder_linux-dkms.git
 BINDER_DIR=$(mktemp -d)/aur_binder
 WAYDROID_SCRIPT=https://github.com/casualsnek/waydroid_script.git
 WAYDROID_SCRIPT_DIR=$(mktemp -d)/waydroid_script
@@ -43,7 +42,7 @@ echo This can take a few minutes depending on the speed of the internet connecti
 echo If the git clone is slow - cancel the script \(CTL-C\) and run it again.
 
 git clone --depth=1 $WAYDROID_SCRIPT $WAYDROID_SCRIPT_DIR &> /dev/null && \
-	git clone $BINDER_AUR $BINDER_DIR &> /dev/null
+	git clone --branch binder_linux-dkms --single-branch https://github.com/archlinux/aur.git $BINDER_DIR &> /dev/null
 
 if [ $? -eq 0 ]
 then


### PR DESCRIPTION
### Summary

The AUR is currently facing a major DDOS attack and is unavailable for most users. This small change is based on the official suggestion of using the GitHub hosted mirror.

## Context
https://archlinux.org/news/recent-services-outages/
https://www.reddit.com/r/archlinux/comments/1mz41u6/updated_recent_service_outage/ 